### PR TITLE
Kanazawa/feature/components layout

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,6 +38,12 @@ export default {
       { name: 'twitter:image', content: 'https://kosen-sparkle.com/ogp.png' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    
+    // ロゴにしようしたFuturaと類似した Renner* を採用しました
+    link: [{rel: "stylesheet", 
+            href: "https://indestructibletype-fonthosting.github.io/renner.css",
+            type: "text/css",
+            charset: "utf-8"}],
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -11,5 +11,7 @@ footer {
   text-align: center;
   background-color: var(--main-bg-color);
   color: var(--font-color-on-main-bg);
+  font-family: 'Renner*';
+  font-weight: 500;
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -17,14 +17,16 @@
 <style scoped>
 header {
   width: 100%;
-  height: 65px;
+  height: 50px;
   padding: 0 40px;
   background-color: var(--main-bg-color);
   color: var(--font-color-on-main-bg);
   display: flex;
   justify-content: center;
   align-items: center;
-  text-shadow: 1px 1px 2px gray;
+  font-family: 'Renner*';
+  font-weight: medium;
+  text-shadow: 1px 1px 1px gray;
 }
 /* #header-title {
   font-size: xx-large;
@@ -37,9 +39,9 @@ ul {
 }
 li {
   height: fit-content !important;
-  font-size: x-large;
+  font-size: large;
   list-style-type: none;
-  letter-spacing: 0.5rem;
+  letter-spacing: 0.1rem;
 }
 #header-title,
 li {

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -55,6 +55,7 @@ import {
 }
 .main-text {
   margin: 0;
+  font-family: 'Renner*';
   font-weight: bolder;
   font-size: 120px;
   letter-spacing: 5px;
@@ -65,8 +66,7 @@ import {
 .sub-text {
   font-size: 30px;
   text-align: center;
-  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande',
-    'Lucida Sans', Arial, sans-serif;
+  font-family: 'Renner*', Arial, sans-serif;
 }
 .description {
   font-family: Courier, monospace;


### PR DESCRIPTION
ロゴのフォントであるFutura（Adobeフォントなので有料）と似通ったやつ「[Renner*](https://www.cdnfonts.com/renner.font)」を拾ってきたので適用。
- index: タイトルとサブタイ
- header: メニューの文字（合わせて文字間隔と帯幅も調整）
- footer: 文字に適用

before | after
--|--
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/43166752/194360991-cff7e566-e855-469e-97d4-47f0d84863b6.png"> | <img width="1552" alt="image" src="https://user-images.githubusercontent.com/43166752/194361075-8be17744-2046-4aa0-bbc2-ffd68a18b00f.png">

気に入らなければまたフォントは探すわ。