### PR TITLE
add reactive variable "path" to highlight selected page

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,14 +1,31 @@
+<script setup lang="ts">
+import { computed, useRoute } from '@nuxtjs/composition-api'
+
+const path = computed(() => {
+  const route = useRoute()
+  return route.value.path
+})
+</script>
+
 <template>
   <header>
     <!-- <div id="header-title">KSparkle</div> -->
     <nav>
       <ul>
         <!-- TODO: トップへの遷移はnavではなくロゴ画像とかで -->
-        <li><NuxtLink to="/">TOP</NuxtLink></li>
-        <li><NuxtLink to="/about">ABOUT</NuxtLink></li>
-        <li><NuxtLink to="/member">MEMBER</NuxtLink></li>
-        <li><NuxtLink to="/work">WORK</NuxtLink></li>
-        <li><NuxtLink to="/contact">CONTACT</NuxtLink></li>
+        <li :selected="path === '/'"><NuxtLink to="/">TOP</NuxtLink></li>
+        <li :selected="path === '/about'">
+          <NuxtLink to="/about">ABOUT</NuxtLink>
+        </li>
+        <li :selected="path === '/member'">
+          <NuxtLink to="/member">MEMBER</NuxtLink>
+        </li>
+        <li :selected="path === '/work'">
+          <NuxtLink to="/work">WORK</NuxtLink>
+        </li>
+        <li :selected="path === '/contact'">
+          <NuxtLink to="/contact">CONTACT</NuxtLink>
+        </li>
       </ul>
     </nav>
   </header>
@@ -49,7 +66,8 @@ a {
   color: white;
 }
 #header-title:hover,
-li:hover {
+li:hover,
+li[selected] a {
   text-shadow: 1px 1px 2px black;
 }
 @media (max-width: 480px) {


### PR DESCRIPTION
# 目的
現在のルートに応じてヘッダーのナビゲーションをハイライト
(ハイライトの仕方はホバー時と同様)

# 結果
<img width="1439" alt="スクリーンショット 2022-10-07 21 30 20" src="https://user-images.githubusercontent.com/44457990/194553977-c909faff-98a8-4a5d-bdec-d9244289a949.png">
